### PR TITLE
Fix/add activate version

### DIFF
--- a/tap_15five/__init__.py
+++ b/tap_15five/__init__.py
@@ -68,6 +68,7 @@ def sync(config, state, catalog):
 
         bookmark_column = stream.replication_key
         is_sorted = True  # TODO: indicate whether data is sorted ascending on bookmark value
+        activate_version_ind = True #full table replication of all streams
 
         singer.write_schema(
             stream_name=stream.tap_stream_id,
@@ -92,6 +93,26 @@ def sync(config, state, catalog):
                     max_bookmark = max(max_bookmark, row[bookmark_column])
         if bookmark_column and not is_sorted:
             singer.write_state({stream.tap_stream_id: max_bookmark})
+
+        if activate_version_ind:
+            activate_version = max_bookmark
+            activate_version_message = singer.ActivateVersionMessage(
+                stream=stream_name,
+                version=activate_version)
+        else:
+            activate_version = None
+
+        if total_records > 0
+            # End of Stream: Send Activate Version (if needed)
+            if activate_version_ind:
+                singer.write_message(activate_version_message)
+        else:
+            LOGGER.warning('NO NEW DATA FOR STREAM: {}'.format(stream_name))
+
+        LOGGER.info('Synced: {}, total_records: {}'.format(
+                        input_stream_id,
+                        total_records))
+        LOGGER.info('FINISHED Syncing: {}'.format(input_stream_id))
 
     return
 

--- a/tap_15five/request_data.py
+++ b/tap_15five/request_data.py
@@ -48,10 +48,7 @@ def tap_data(config, input_stream_id, columns):
         else:
             list_endpoint = r_list['next']
 
-    LOGGER.info('Synced: {}, total_records: {}'.format(
-                    input_stream_id,
-                    total_records))
-    LOGGER.info('FINISHED Syncing: {}'.format(input_stream_id))
+
 
 
 def sample_data(input_stream_id, columns):

--- a/tap_state.json
+++ b/tap_state.json
@@ -1,6 +1,15 @@
 {
   "bookmarks": {
-    "pulse": {
+    "pulses": {
+      "last_record": "2018-01-01T00:00:00Z"
+    }
+    "reports": {
+      "last_record": "2018-01-01T00:00:00Z"
+    }
+    "users": {
+      "last_record": "2018-01-01T00:00:00Z"
+    }
+    "groups": {
       "last_record": "2018-01-01T00:00:00Z"
     }
   }


### PR DESCRIPTION
The singer activate_version message tells Stitch to truncate the target table in order to enable full table replication without a separate drop table script. Documentation on this is not great; pieced it together from the slack conversation starting here: https://singer-io.slack.com/archives/C7PUW7ZR7/p1588104139010400. 