### PR TITLE
move trove tap15_five config files to repository from dw-etl-core

### DIFF
--- a/config/tap_15five_config.json
+++ b/config/tap_15five_config.json
@@ -1,0 +1,5 @@
+{
+  "start_date" : "2018-01-01T00:00:00Z",
+  "access_token" : "{{_15five_api_token_for_data_sync}}",
+  "user_agent" : "Trove - analytics@trove.co"
+}

--- a/config/target_stitch_config.json
+++ b/config/target_stitch_config.json
@@ -1,0 +1,7 @@
+{
+"client_id": 145670,
+"token": "{{stitch_singer_api_key_15five_load}}",
+"small_batch_url": "https://api.stitchdata.com/v2/import/batch",
+"big_batch_url": "https://api.stitchdata.com/v2/import/batch",
+"batch_size_preferences": {}
+}


### PR DESCRIPTION
To conform to DevOps standard, each repository should have its own /config folder containing scripts with Jinja replacement variables. Ansible can act on these scripts during autodeployment.