### PR TITLE
fix ansible variable name

### DIFF
--- a/config/tap_15five_config.json
+++ b/config/tap_15five_config.json
@@ -1,5 +1,5 @@
 {
   "start_date" : "2018-01-01T00:00:00Z",
-  "access_token" : "{{_15five_api_token_for_data_sync}}",
+  "access_token" : "{{15five_api_token_for_data_sync}}",
   "user_agent" : "Trove - analytics@trove.co"
 }


### PR DESCRIPTION
It appears an underscore got inserted where it didn't belong, and may be crashing the deployment script.